### PR TITLE
ci: Improve codecov.io integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,7 @@ jobs:
             yarn test --ci --reporters=default --reporters=jest-junit --collectCoverage --coverageReporters lcov --coverage
       - store_test_results:
           path: junit.xml
-      - codecov/upload:
-          file: junit.xml
+      - codecov/upload
   release:
     executor: node/default
     steps:


### PR DESCRIPTION
## Description
Push lcov, which contains more information for codecov.io than the junit file, used by CircleCI