### PR TITLE
fix: update detectIsoFormat for case-insensitive ISO detection

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,6 +2,7 @@ import {
   convertIso2ToIso3,
   convertIso3ToIso2,
   detectedIsoFormat,
+  detectIsoFormat,
   convertIso,
 } from ".";
 
@@ -35,6 +36,9 @@ describe("detectedIsoFormat", () => {
   });
   it("should detect ISO3", () => {
     expect(detectedIsoFormat(ISO3_GERMANY)).toBe("ISO3");
+  });
+  it("should verify the alias detectIsoFormat exists", () => {
+    expect(detectIsoFormat).toBe(detectedIsoFormat);
   });
   it("should throw an error if the ISO code is invalid", () => {
     // @ts-ignore - we want to test invalid ISO codes

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,17 +316,19 @@ export const convertIso3ToIso2 = (iso3: ISO3): ISO2 => {
  * detectedIsoFormat("GB2") // Error
  */
 export const detectedIsoFormat = (iso: string): "ISO2" | "ISO3" => {
-  if (isoMapping.get(iso) === undefined) {
+  const capitalisedIso = iso.toUpperCase();
+  if (isoMapping.get(capitalisedIso) === undefined) {
     throw new Error("ISO Code seems to be neither a valid ISO2 or ISO3 code");
   }
-  if (iso.length === 2) {
+  if (capitalisedIso.length === 2) {
     return "ISO2";
   }
-  if (iso.length === 3) {
+  if (capitalisedIso.length === 3) {
     return "ISO3";
   }
   throw new Error("ISO Code seems to be neither a valid ISO2 or ISO3 code");
 };
+export const detectIsoFormat = detectedIsoFormat
 
 /**
  * Convert an ISO2 or ISO3 country code to the other format.


### PR DESCRIPTION

## Description
The PR addresses the following: 
- Enables `detectedIsoFormat` to look up ISOs regardless of case.
- ALIASes `detectIsoFormat` to `detectedIsoFormat` which I believe was its intended name as per the [README](https://github.com/trustedshops-public/js-iso3166-converter?tab=readme-ov-file#detect-iso-format)